### PR TITLE
When Observable fails, catch that failure and send the error

### DIFF
--- a/angular-rest-application/src/app/services/reqres.service.ts
+++ b/angular-rest-application/src/app/services/reqres.service.ts
@@ -24,4 +24,15 @@ export class ReqresService {
     const url = `${this.url}/${id}`;
     return this.http.get<User>(url);
   }
+
+  private handleError<T>(operation = 'operation', result?: T):any {
+    return(error: any): Observable<T> => {
+      
+      // TODO: send the error to remote logging infrastructure
+      console.log(error);
+
+      // Let the app keep running by returning an empty result
+      return of(result as T);
+    };
+  }
 }


### PR DESCRIPTION
When the Observable fails, catchError will catch that failure and send the error to the function we define within the operator